### PR TITLE
update to codesniffer 2.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This code works with [phpcs](https://github.com/squizlabs/PHP_CodeSniffer) and c
 It's generally recommended to install these code sniffs with `composer`:
 
 ```sh
-composer global require --dev 'cakephp/cakephp-codesniffer=1.*';
+composer global require --dev 'cakephp/cakephp-codesniffer=2.*';
 ```
 
 Modify `~/.composer/composer.json`.

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 	],
 	"require": {
 		"php": ">=5.3.10",
-		"cakephp/cakephp-codesniffer": "1.*"
+		"cakephp/cakephp-codesniffer": "2.*"
 	},
 	"support": {
 		"issues": "https://github.com/Oefenweb/cakephp-codesniffer/issues",


### PR DESCRIPTION
We would need to adjust a few rules or comply to them, because they use PSR2 now..

> The master branch contains codesniffer rules that are based on the PSR2 standard. If you want to check against the historical CakePHP coding standard use any of the 1.x releases.
> https://github.com/cakephp/cakephp-codesniffer

```
- Spaces must be used to indent lines; tabs are not allowed
- Expected "string" but found "String" for function return type
- Short array syntax must be used to define arrays
- Opening brace should be on a new line
```
