### PR TITLE
Add PHPCompatibility sniffs

### DIFF
--- a/CakePHPOefenweb/ruleset.xml
+++ b/CakePHPOefenweb/ruleset.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0"?>
 <ruleset name="CakePHPOefenweb">
 	<description>Oefenweb Code Sniffer for CakePHP 3</description>
-	<rule ref="../../../cakephp/cakephp-codesniffer/CakePHP">
+	<rule ref="CakePHP">
 		<exclude name="Generic.Commenting.Todo"/>
+	</rule>
+    
+	<rule ref="PHPCompatibility">
+		<config name="testVersion" value="7.2-8.0"/>
+		<exclude name="PHPCompatibility.Extensions.RemovedExtensions"/>
 	</rule>
 </ruleset>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ mkdir CakePHP3Oefenweb && cd $_ && composer require oefenweb/cakephp-codesniffer
 
 ```sh
 vendor/bin/phpcs \
-  --config-set installed_paths "${PWD}/vendor/cakephp/cakephp-codesniffer,${PWD}/vendor/oefenweb/cakephp-codesniffer" \
+  --config-set installed_paths "${PWD}/vendor/cakephp/cakephp-codesniffer,${PWD}/vendor/oefenweb/cakephp-codesniffer,${PWD}/vendor/phpcompatibility/php-compatibility" \
 ;
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
 	],
 	"require": {
 		"php": ">=5.4",
-		"cakephp/cakephp-codesniffer": "^3.0.0"
+		"cakephp/cakephp-codesniffer": "^3.0.0",
+		"phpcompatibility/php-compatibility": "^9.0"
 	},
 	"support": {
 		"issues": "https://github.com/Oefenweb/cakephp-codesniffer/issues",


### PR DESCRIPTION
PHPCompatibility allows us to detect PHP version compatibility issues sooner. The range is now set to 7.2-8.0, not sure if that's exactly what we want but it's a start.